### PR TITLE
Sort balance by Threads_running first

### DIFF
--- a/health.go
+++ b/health.go
@@ -15,6 +15,7 @@ type ServerHealth struct {
 
 	secondsBehindMaster *int
 	openConnections     *int
+	runningConnections  *int
 }
 
 // IsUP returns if the server is UP
@@ -39,22 +40,29 @@ func (h *ServerHealth) GetOpenConnections() *int {
 	return h.openConnections
 }
 
-func (h *ServerHealth) setUP(secondsBehindMaster *int, openConnections *int) {
+// GetRunningConnections returns the number of connections that are not sleeping.
+func (h *ServerHealth) GetRunningConnections() *int {
+	return h.runningConnections
+}
+
+func (h *ServerHealth) setUP(secondsBehindMaster, openConnections, runningConnections *int) {
 	h.Lock()
 	defer h.Unlock()
 	h.up = true
 	h.err = nil
 	h.secondsBehindMaster = secondsBehindMaster
 	h.openConnections = openConnections
+	h.runningConnections = runningConnections
 	h.lastUpdate = time.Now()
 }
 
-func (h *ServerHealth) setDown(err error, secondsBehindMaster *int, openConnections *int) {
+func (h *ServerHealth) setDown(err error, secondsBehindMaster, openConnections, runningConnections *int) {
 	h.Lock()
 	defer h.Unlock()
 	h.up = false
 	h.err = err
 	h.secondsBehindMaster = secondsBehindMaster
 	h.openConnections = openConnections
+	h.runningConnections = runningConnections
 	h.lastUpdate = time.Now()
 }


### PR DESCRIPTION
sorts slaves by number of connections that are actually executing tasks (threads_running), if equal sorts by number of open connections (Threads_connected)

Analyzing some data I saw that some slaves despite having more connections (pool of several services at the same time) they had less load than others. Then I realized that ordering first by really active threads was more important. This post explains this point well:
https://www.percona.com/blog/2010/03/19/is-your-mysql-server-loaded/

e.g. in production (no load on any of the 3 slaves for a good example, but it balances a little better anyway.)
<img width="765" alt="captura de tela 2017-09-12 as 19 53 38" src="https://user-images.githubusercontent.com/329975/30352265-729a494c-97f5-11e7-8d26-3157d6febdf0.png">

