### PR TITLE
Add startup wait time for checking slaves

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	TraceOn         bool
 	Logger          Logger
 	ServersSettings []ServerSettings
+	StartupWait     time.Duration
 }
 
 // ServerSettings servers' configuration options


### PR DESCRIPTION
## Qual o problema inicial?
A aplicação pode solicitar um slave antes do check async ter executado.

## O que esse PR faz?
Aguarda até um limit máximo definido em options.StartupWait (default 5s) ou até o check inicial ser concluído.

## Como testar?