### PR TITLE
Changes server status (up) when it can connect but contains replication errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.11
+- 1.12
 go_import_path: github.com/StudioSol/balancer
 install:
   - make upgrade

--- a/balancer.go
+++ b/balancer.go
@@ -13,12 +13,16 @@ type bySecondsBehindMaster Servers
 func (a bySecondsBehindMaster) Len() int      { return len(a) }
 func (a bySecondsBehindMaster) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a bySecondsBehindMaster) Less(i, j int) bool {
+	if a[i].health.secondsBehindMaster == nil && a[j].health.secondsBehindMaster == nil {
+		return false
+	}
 	if a[i].health.secondsBehindMaster == nil && a[j].health.secondsBehindMaster != nil {
 		return false
 	}
 	if a[i].health.secondsBehindMaster != nil && a[j].health.secondsBehindMaster == nil {
 		return true
 	}
+
 	return *a[i].health.secondsBehindMaster < *a[j].health.secondsBehindMaster
 }
 
@@ -27,7 +31,6 @@ type byConnections Servers
 func (a byConnections) Len() int      { return len(a) }
 func (a byConnections) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a byConnections) Less(i, j int) bool {
-
 	if a[i].health.runningConnections == nil && a[j].health.runningConnections != nil {
 		return false
 	}
@@ -37,6 +40,9 @@ func (a byConnections) Less(i, j int) bool {
 
 	if a[i].health.runningConnections == a[j].health.runningConnections {
 
+		if a[i].health.openConnections == nil && a[j].health.openConnections == nil {
+			return false
+		}
 		if a[i].health.openConnections == nil && a[j].health.openConnections != nil {
 			return false
 		}

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	TraceOn         bool
 	Logger          Logger
 	ServersSettings []ServerSettings
+	StartupWait     time.Duration
 }
 
 // ServerSettings servers' configuration options

--- a/health.go
+++ b/health.go
@@ -45,24 +45,21 @@ func (h *ServerHealth) GetRunningConnections() *int {
 	return h.runningConnections
 }
 
-func (h *ServerHealth) setUP(secondsBehindMaster, openConnections, runningConnections *int) {
+func (h *ServerHealth) setStatus(up bool, err error, secondsBehindMaster, openConnections, runningConnections *int) {
 	h.Lock()
 	defer h.Unlock()
-	h.up = true
-	h.err = nil
+	h.up = up
+	h.err = err
 	h.secondsBehindMaster = secondsBehindMaster
 	h.openConnections = openConnections
 	h.runningConnections = runningConnections
 	h.lastUpdate = time.Now()
 }
 
+func (h *ServerHealth) setUP(err error, secondsBehindMaster, openConnections, runningConnections *int) {
+	h.setStatus(true, err, secondsBehindMaster, openConnections, runningConnections)
+}
+
 func (h *ServerHealth) setDown(err error, secondsBehindMaster, openConnections, runningConnections *int) {
-	h.Lock()
-	defer h.Unlock()
-	h.up = false
-	h.err = err
-	h.secondsBehindMaster = secondsBehindMaster
-	h.openConnections = openConnections
-	h.runningConnections = runningConnections
-	h.lastUpdate = time.Now()
+	h.setStatus(false, err, secondsBehindMaster, openConnections, runningConnections)
 }


### PR DESCRIPTION
today, when we have problems with master server and slaves can`t replicate (for example master fallen), the balancer does not return any slave even though they are up and running.

ex replication status: 
```
error reconnecting to master 'replicar@mysql-master:3306' - retry-time: 10  maximum-retries: 86400  message: Can't connect to MySQL server on 'mysql-master' (110 "Connection timed out")
```

- This PR set the status of error, but consider the server up.
- If has a server without error, it continues with preference.

ps: for health checks it is necessary to check if the server has errors and not only if it is up.

```go
serverHealth := server.GetHealth()
if !serverHealth.IsUP() || serverHealth.GetErr() != nil {
h.Unhealthy(serverHealth.GetErr())
}
```



