### PR TITLE
feat(health): inlcude IO status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 go:
-- 1.12
+- 1.14
 go_import_path: github.com/StudioSol/balancer
 install:
-  - make upgrade
+  - make deps
 script:
   - make test
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,7 @@ build:
 clean: 
 	go clean
 deps: 
-	go build -v ./...
-upgrade: 
-	go get -u
+	go mod download
 test:
 	echo "" > coverage.txt
 	for d in $(shell go list ./...); do \

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -26,7 +26,7 @@ func init() {
 		health: &ServerHealth{},
 	}
 	ServerDownDueToMySQLConnection.health.setDown(
-		errors.New("__MYSQL_CONNECTION_ERROR__"), intNilHelper, intNilHelper, intNilHelper,
+		errors.New("__MYSQL_CONNECTION_ERROR__"), false, intNilHelper, intNilHelper, intNilHelper,
 	)
 
 	ServerUPWithMySQLSlaveStatusError = &Server{
@@ -34,7 +34,7 @@ func init() {
 		health: &ServerHealth{},
 	}
 	ServerUPWithMySQLSlaveStatusError.health.setUP(
-		errors.New("__MYSQL_SLAVE_STATUS_ERROR__"), intNilHelper, intNilHelper, intNilHelper,
+		errors.New("__MYSQL_SLAVE_STATUS_ERROR__"), false, intNilHelper, intNilHelper, intNilHelper,
 	)
 
 	ServerUPWithMySQLThreadStatusError = &Server{
@@ -42,38 +42,38 @@ func init() {
 		health: &ServerHealth{},
 	}
 	ServerUPWithMySQLThreadStatusError.health.setUP(
-		errors.New("__MYSQL_THREADS_STATUS_ERROR__"), intNilHelper, intNilHelper, intNilHelper,
+		errors.New("__MYSQL_THREADS_STATUS_ERROR__"), false, intNilHelper, intNilHelper, intNilHelper,
 	)
 
 	ServerUP = &Server{
 		name:   "ServerUP",
 		health: &ServerHealth{},
 	}
-	ServerUP.health.setUP(nil, &zeroHelper, &oneHelper, &oneHelper)
+	ServerUP.health.setUP(nil, true, &zeroHelper, &oneHelper, &oneHelper)
 
 	ServerUPWithDelay = &Server{
 		name:   "ServerUPWithDelay",
 		health: &ServerHealth{},
 	}
-	ServerUPWithDelay.health.setUP(nil, &thousandHelper, &oneHelper, &oneHelper)
+	ServerUPWithDelay.health.setUP(nil, true, &thousandHelper, &oneHelper, &oneHelper)
 
 	ServerUPWithHighThreadConnections = &Server{
 		name:   "ServerUPWithHighThreadConnections",
 		health: &ServerHealth{},
 	}
-	ServerUPWithHighThreadConnections.health.setUP(nil, &zeroHelper, &thousandHelper, &oneHelper)
+	ServerUPWithHighThreadConnections.health.setUP(nil, true, &zeroHelper, &thousandHelper, &oneHelper)
 
 	ServerUPWithDelayAndHighThreadConnections = &Server{
 		name:   "ServerUPWithDelayAndHighThreadConnections",
 		health: &ServerHealth{},
 	}
-	ServerUPWithDelayAndHighThreadConnections.health.setUP(nil, &thousandHelper, &thousandHelper, &oneHelper)
+	ServerUPWithDelayAndHighThreadConnections.health.setUP(nil, true, &thousandHelper, &thousandHelper, &oneHelper)
 
 	ServerUPWithHighRunningConnections = &Server{
 		name:   "ServerUPWithHighRunningConnections",
 		health: &ServerHealth{},
 	}
-	ServerUPWithHighRunningConnections.health.setUP(nil, &zeroHelper, &thousandHelper, &thousandHelper)
+	ServerUPWithHighRunningConnections.health.setUP(nil, true, &zeroHelper, &thousandHelper, &thousandHelper)
 }
 
 func TestBalancer(t *testing.T) {

--- a/health.go
+++ b/health.go
@@ -11,6 +11,7 @@ type ServerHealth struct {
 
 	up         bool
 	err        error
+	ioRunning  bool
 	lastUpdate time.Time
 
 	secondsBehindMaster *int
@@ -45,10 +46,16 @@ func (h *ServerHealth) GetRunningConnections() *int {
 	return h.runningConnections
 }
 
-func (h *ServerHealth) setStatus(up bool, err error, secondsBehindMaster, openConnections, runningConnections *int) {
+// GetSlaveRunning returns the IO status from slave
+func (h *ServerHealth) IORunning() bool {
+	return h.ioRunning
+}
+
+func (h *ServerHealth) setStatus(up, ioRunning bool, err error, secondsBehindMaster, openConnections, runningConnections *int) {
 	h.Lock()
 	defer h.Unlock()
 	h.up = up
+	h.ioRunning = ioRunning
 	h.err = err
 	h.secondsBehindMaster = secondsBehindMaster
 	h.openConnections = openConnections
@@ -56,10 +63,10 @@ func (h *ServerHealth) setStatus(up bool, err error, secondsBehindMaster, openCo
 	h.lastUpdate = time.Now()
 }
 
-func (h *ServerHealth) setUP(err error, secondsBehindMaster, openConnections, runningConnections *int) {
-	h.setStatus(true, err, secondsBehindMaster, openConnections, runningConnections)
+func (h *ServerHealth) setUP(err error, ioRunning bool, secondsBehindMaster, openConnections, runningConnections *int) {
+	h.setStatus(true, ioRunning, err, secondsBehindMaster, openConnections, runningConnections)
 }
 
-func (h *ServerHealth) setDown(err error, secondsBehindMaster, openConnections, runningConnections *int) {
-	h.setStatus(false, err, secondsBehindMaster, openConnections, runningConnections)
+func (h *ServerHealth) setDown(err error, ioRunning bool, secondsBehindMaster, openConnections, runningConnections *int) {
+	h.setStatus(false, ioRunning, err, secondsBehindMaster, openConnections, runningConnections)
 }

--- a/health_test.go
+++ b/health_test.go
@@ -16,6 +16,7 @@ func TestHealthAttributes(t *testing.T) {
 			openConnections:     &[]int{1}[0],
 			runningConnections:  &[]int{2}[0],
 			secondsBehindMaster: &[]int{3}[0],
+			ioRunning:           true,
 		}
 
 		Convey("It should return correct values", func() {
@@ -23,6 +24,7 @@ func TestHealthAttributes(t *testing.T) {
 			So(*health.GetOpenConnections(), ShouldEqual, 1)
 			So(*health.GetRunningConnections(), ShouldEqual, 2)
 			So(*health.GetSecondsBehindMaster(), ShouldEqual, 3)
+			So(health.IORunning(), ShouldBeTrue)
 		})
 	})
 }


### PR DESCRIPTION
Include a variable to check IO Status from slaves.

![image](https://user-images.githubusercontent.com/7620947/84273679-548e0080-ab05-11ea-928f-bc2d9cc96ef1.png)

From documentation: https://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Slave_running
> This is ON if this server is a replication slave that is connected to a replication master, and both the I/O and SQL threads are running; otherwise, it is OFF.

For now, it will be used only in health checks, to check the status behavior. In the next steps, we can use it to set status down.
