### PR TITLE
fix(race): include mutex to avoid race conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,3 @@ install:
   - make deps
 script:
   - make test
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,4 @@ test:
 		go test -race -v -coverprofile=profile.out -covermode=atomic $$d || exit 1; \
 		[ -f profile.out ] && cat profile.out >> coverage.txt && rm profile.out; \
 	done
+	cat coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,4 @@ clean:
 deps: 
 	go mod download
 test:
-	echo "" > coverage.txt
-	for d in $(shell go list ./...); do \
-		go test -race -v -coverprofile=profile.out -covermode=atomic $$d || exit 1; \
-		[ -f profile.out ] && cat profile.out >> coverage.txt && rm profile.out; \
-	done
-	cat coverage.txt
+	go test -race -cover ./...

--- a/server.go
+++ b/server.go
@@ -14,7 +14,7 @@ var mutex sync.Mutex
 
 // Server server representation
 type Server struct {
-	mtx                   sync.RWMutex
+	sync.RWMutex
 	name                  string
 	health                *ServerHealth
 	serverSettings        ServerSettings
@@ -71,22 +71,22 @@ func (s *Server) CheckHealth(traceOn bool, logger Logger) {
 	var secondsBehindMaster, openConnections, runningConnections *int
 
 	// prevent concurrently checks on same server (slow queries/network)
-	s.mtx.RLock()
+	s.RLock()
 	checking := s.isChecking
-	s.mtx.RUnlock()
+	s.RUnlock()
 
 	if checking {
 		return
 	}
 
-	s.mtx.Lock()
+	s.Lock()
 	s.isChecking = true
-	s.mtx.Unlock()
+	s.Unlock()
 
 	defer func() {
-		s.mtx.Lock()
+		s.Lock()
 		s.isChecking = false
-		s.mtx.Unlock()
+		s.Unlock()
 	}()
 
 	if err := s.connectReadUser(traceOn, logger); err != nil {


### PR DESCRIPTION
This function is checked asynchronously when we use more than two servers.

## Changes
- Remove codecov due recent Leak (https://about.codecov.io/security-update/)
- Include Mutex

```
WARNING: DATA RACE
--
157 | Read at 0x00c00043a6f1 by goroutine 39:
158 | github.com/StudioSol/balancer.(*Server).CheckHealth()
159 | /project/vendor/github.com/StudioSol/balancer/server.go:73 +0x61
160 | github.com/StudioSol/balancer.(*Balancer).check.func1()
161 | /project/vendor/github.com/StudioSol/balancer/balancer.go:86 +0x98
162 |  
163 | Previous write at 0x00c00043a6f1 by goroutine 36:
164 | github.com/StudioSol/balancer.(*Server).CheckHealth.func1()
165 | /project/vendor/github.com/StudioSol/balancer/server.go:79 +0x3e
166 | github.com/StudioSol/balancer.(*Server).CheckHealth()
167 | /project/vendor/github.com/StudioSol/balancer/server.go:86 +0xf08
168 | github.com/StudioSol/balancer.(*Balancer).check.func1()
169 | /project/vendor/github.com/StudioSol/balancer/balancer.go:86 +0x98
```